### PR TITLE
Code review cleanup: remove dead code, deduplicate, simplify

### DIFF
--- a/src/main/java/com/didww/sdk/DidwwClient.java
+++ b/src/main/java/com/didww/sdk/DidwwClient.java
@@ -194,8 +194,6 @@ public class DidwwClient {
             try (OutputStream out = Files.newOutputStream(destination)) {
                 out.write(response.body().bytes());
             }
-        } catch (DidwwClientException e) {
-            throw e;
         } catch (IOException e) {
             throw new DidwwClientException("Failed to download export", e);
         }

--- a/src/main/java/com/didww/sdk/callback/RequestValidator.java
+++ b/src/main/java/com/didww/sdk/callback/RequestValidator.java
@@ -3,6 +3,7 @@ package com.didww.sdk.callback;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -61,8 +62,8 @@ public class RequestValidator {
     private static String hmacSha1(String data, String key) {
         try {
             Mac mac = Mac.getInstance("HmacSHA1");
-            mac.init(new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA1"));
-            byte[] rawHmac = mac.doFinal(data.getBytes("UTF-8"));
+            mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA1"));
+            byte[] rawHmac = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
             StringBuilder sb = new StringBuilder();
             for (byte b : rawHmac) {
                 sb.append(String.format("%02x", b));

--- a/src/main/java/com/didww/sdk/converter/DidwwResourceConverter.java
+++ b/src/main/java/com/didww/sdk/converter/DidwwResourceConverter.java
@@ -59,10 +59,6 @@ public class DidwwResourceConverter {
         return mapper;
     }
 
-    public static ResourceConverter create() {
-        return create(createObjectMapper());
-    }
-
     public static ResourceConverter create(ObjectMapper objectMapper) {
         ResourceConverter converter = new ResourceConverter(objectMapper, ALL_RESOURCE_CLASSES);
         converter.enableDeserializationOption(com.github.jasminb.jsonapi.DeserializationFeature.ALLOW_UNKNOWN_INCLUSIONS);

--- a/src/main/java/com/didww/sdk/converter/OrderItemDeserializer.java
+++ b/src/main/java/com/didww/sdk/converter/OrderItemDeserializer.java
@@ -1,8 +1,7 @@
 package com.didww.sdk.converter;
 
-import com.didww.sdk.resource.orderitem.*;
+import com.didww.sdk.resource.orderitem.OrderItem;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,21 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class OrderItemDeserializer extends JsonDeserializer<List<OrderItem>> {
-
-    private static final Map<String, Class<? extends OrderItem>> TYPE_MAP = new HashMap<>();
-
-    static {
-        TYPE_MAP.put("did_order_items", DidOrderItem.class);
-        TYPE_MAP.put("available_did_order_items", AvailableDidOrderItem.class);
-        TYPE_MAP.put("reservation_did_order_items", ReservationDidOrderItem.class);
-        TYPE_MAP.put("capacity_order_items", CapacityOrderItem.class);
-        TYPE_MAP.put("generic_order_items", GenericOrderItem.class);
-    }
 
     @Override
     public List<OrderItem> deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
@@ -38,32 +25,10 @@ public class OrderItemDeserializer extends JsonDeserializer<List<OrderItem>> {
         List<OrderItem> items = new ArrayList<>();
         if (node.isArray()) {
             for (JsonNode itemNode : node) {
-                items.add(deserializeItem(mapper, itemNode));
+                items.add(PolymorphicJsonHelper.deserialize(mapper, itemNode,
+                        OrderItem.getTypeMap(), "order item"));
             }
         }
         return items;
-    }
-
-    private OrderItem deserializeItem(ObjectMapper mapper, JsonNode node) throws IOException {
-        String type = node.has("type") ? node.get("type").asText() : null;
-        if (type == null) {
-            throw new IOException("Missing 'type' field in order item");
-        }
-
-        Class<? extends OrderItem> clazz = TYPE_MAP.get(type);
-        if (clazz == null) {
-            throw new IOException("Unknown order item type: " + type);
-        }
-
-        JsonNode attributes = node.get("attributes");
-        if (attributes == null) {
-            try {
-                return clazz.getDeclaredConstructor().newInstance();
-            } catch (Exception e) {
-                throw new IOException("Cannot instantiate " + clazz.getName(), e);
-            }
-        }
-
-        return mapper.treeToValue(attributes, clazz);
     }
 }

--- a/src/main/java/com/didww/sdk/converter/OrderItemSerializer.java
+++ b/src/main/java/com/didww/sdk/converter/OrderItemSerializer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 import java.util.List;
@@ -13,20 +12,16 @@ import java.util.List;
 public class OrderItemSerializer extends JsonSerializer<List<OrderItem>> {
 
     @Override
-    public void serialize(List<OrderItem> value, JsonGenerator gen, SerializerProvider serializers)
-            throws IOException {
+    public void serialize(List<OrderItem> value, JsonGenerator gen,
+                          SerializerProvider serializers) throws IOException {
         if (value == null) {
             gen.writeNull();
             return;
         }
-
         ObjectMapper mapper = (ObjectMapper) gen.getCodec();
         gen.writeStartArray();
         for (OrderItem item : value) {
-            ObjectNode wrapper = mapper.createObjectNode();
-            wrapper.put("type", item.getType());
-            wrapper.set("attributes", mapper.valueToTree(item));
-            gen.writeTree(wrapper);
+            PolymorphicJsonHelper.serialize(item, item.getType(), gen, mapper);
         }
         gen.writeEndArray();
     }

--- a/src/main/java/com/didww/sdk/converter/PolymorphicJsonHelper.java
+++ b/src/main/java/com/didww/sdk/converter/PolymorphicJsonHelper.java
@@ -1,0 +1,45 @@
+package com.didww.sdk.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.util.Map;
+
+class PolymorphicJsonHelper {
+
+    static <T> T deserialize(ObjectMapper mapper, JsonNode node,
+                             Map<String, Class<? extends T>> typeMap,
+                             String entityName) throws IOException {
+        String type = node.has("type") ? node.get("type").asText() : null;
+        if (type == null) {
+            throw new IOException("Missing 'type' field in " + entityName);
+        }
+
+        Class<? extends T> clazz = typeMap.get(type);
+        if (clazz == null) {
+            throw new IOException("Unknown " + entityName + " type: " + type);
+        }
+
+        JsonNode attributes = node.get("attributes");
+        if (attributes == null) {
+            try {
+                return clazz.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new IOException("Cannot instantiate " + clazz.getName(), e);
+            }
+        }
+
+        return mapper.treeToValue(attributes, clazz);
+    }
+
+    static void serialize(Object value, String type, JsonGenerator gen,
+                          ObjectMapper mapper) throws IOException {
+        ObjectNode wrapper = mapper.createObjectNode();
+        wrapper.put("type", type);
+        wrapper.set("attributes", mapper.valueToTree(value));
+        gen.writeTree(wrapper);
+    }
+}

--- a/src/main/java/com/didww/sdk/converter/TrunkConfigurationDeserializer.java
+++ b/src/main/java/com/didww/sdk/converter/TrunkConfigurationDeserializer.java
@@ -1,6 +1,6 @@
 package com.didww.sdk.converter;
 
-import com.didww.sdk.resource.configuration.*;
+import com.didww.sdk.resource.configuration.TrunkConfiguration;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -8,19 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class TrunkConfigurationDeserializer extends JsonDeserializer<TrunkConfiguration> {
-
-    private static final Map<String, Class<? extends TrunkConfiguration>> TYPE_MAP = new HashMap<>();
-
-    static {
-        TYPE_MAP.put("sip_configurations", SipConfiguration.class);
-        TYPE_MAP.put("h323_configurations", H323Configuration.class);
-        TYPE_MAP.put("iax2_configurations", Iax2Configuration.class);
-        TYPE_MAP.put("pstn_configurations", PstnConfiguration.class);
-    }
 
     @Override
     public TrunkConfiguration deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
@@ -31,25 +20,7 @@ public class TrunkConfigurationDeserializer extends JsonDeserializer<TrunkConfig
             return null;
         }
 
-        String type = node.has("type") ? node.get("type").asText() : null;
-        if (type == null) {
-            throw new IOException("Missing 'type' field in trunk configuration");
-        }
-
-        Class<? extends TrunkConfiguration> clazz = TYPE_MAP.get(type);
-        if (clazz == null) {
-            throw new IOException("Unknown trunk configuration type: " + type);
-        }
-
-        JsonNode attributes = node.get("attributes");
-        if (attributes == null) {
-            try {
-                return clazz.getDeclaredConstructor().newInstance();
-            } catch (Exception e) {
-                throw new IOException("Cannot instantiate " + clazz.getName(), e);
-            }
-        }
-
-        return mapper.treeToValue(attributes, clazz);
+        return PolymorphicJsonHelper.deserialize(mapper, node,
+                TrunkConfiguration.getTypeMap(), "trunk configuration");
     }
 }

--- a/src/main/java/com/didww/sdk/converter/TrunkConfigurationSerializer.java
+++ b/src/main/java/com/didww/sdk/converter/TrunkConfigurationSerializer.java
@@ -5,24 +5,19 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
 
 public class TrunkConfigurationSerializer extends JsonSerializer<TrunkConfiguration> {
 
     @Override
-    public void serialize(TrunkConfiguration value, JsonGenerator gen, SerializerProvider serializers)
-            throws IOException {
+    public void serialize(TrunkConfiguration value, JsonGenerator gen,
+                          SerializerProvider serializers) throws IOException {
         if (value == null) {
             gen.writeNull();
             return;
         }
-
-        ObjectMapper mapper = (ObjectMapper) gen.getCodec();
-        ObjectNode wrapper = mapper.createObjectNode();
-        wrapper.put("type", value.getType());
-        wrapper.set("attributes", mapper.valueToTree(value));
-        gen.writeTree(wrapper);
+        PolymorphicJsonHelper.serialize(value, value.getType(), gen,
+                (ObjectMapper) gen.getCodec());
     }
 }

--- a/src/main/java/com/didww/sdk/http/QueryParams.java
+++ b/src/main/java/com/didww/sdk/http/QueryParams.java
@@ -1,6 +1,5 @@
 package com.didww.sdk.http;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -50,11 +49,7 @@ public class QueryParams {
     }
 
     private static String encode(String value) {
-        try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 
     public static class Builder {

--- a/src/main/java/com/didww/sdk/repository/ReadOnlyRepository.java
+++ b/src/main/java/com/didww/sdk/repository/ReadOnlyRepository.java
@@ -2,7 +2,6 @@ package com.didww.sdk.repository;
 
 import com.didww.sdk.exception.DidwwApiException;
 import com.didww.sdk.exception.DidwwClientException;
-import com.didww.sdk.http.JsonApiMediaType;
 import com.didww.sdk.http.QueryParams;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,7 +50,7 @@ public class ReadOnlyRepository<T> {
             JSONAPIDocument<List<T>> document = converter.readDocumentCollection(body, resourceClass);
             Map<String, Object> meta = extractMeta(document);
             return new ApiResponse<>(document.get(), meta);
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to list " + endpoint, e);
@@ -72,7 +71,7 @@ public class ReadOnlyRepository<T> {
             JSONAPIDocument<T> document = converter.readDocument(body, resourceClass);
             Map<String, Object> meta = extractMeta(document);
             return new ApiResponse<>(document.get(), meta);
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to find " + endpoint + "/" + id, e);

--- a/src/main/java/com/didww/sdk/repository/Repository.java
+++ b/src/main/java/com/didww/sdk/repository/Repository.java
@@ -1,6 +1,5 @@
 package com.didww.sdk.repository;
 
-import com.didww.sdk.exception.DidwwApiException;
 import com.didww.sdk.exception.DidwwClientException;
 import com.didww.sdk.http.JsonApiMediaType;
 import com.didww.sdk.http.QueryParams;
@@ -43,7 +42,7 @@ public class Repository<T extends BaseResource> extends ReadOnlyRepository<T> {
             byte[] responseBody = getResponseBody(response);
             JSONAPIDocument<T> responseDoc = converter.readDocument(responseBody, resourceClass);
             return new ApiResponse<>(responseDoc.get(), extractMeta(responseDoc));
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to create " + endpoint, e);
@@ -73,7 +72,7 @@ public class Repository<T extends BaseResource> extends ReadOnlyRepository<T> {
             byte[] responseBody = getResponseBody(response);
             JSONAPIDocument<T> responseDoc = converter.readDocument(responseBody, resourceClass);
             return new ApiResponse<>(responseDoc.get(), extractMeta(responseDoc));
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to update " + endpoint + "/" + id, e);
@@ -86,7 +85,7 @@ public class Repository<T extends BaseResource> extends ReadOnlyRepository<T> {
 
         try (Response response = httpClient.newCall(request).execute()) {
             handleErrorResponse(response);
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to delete " + endpoint + "/" + id, e);

--- a/src/main/java/com/didww/sdk/repository/SingletonRepository.java
+++ b/src/main/java/com/didww/sdk/repository/SingletonRepository.java
@@ -1,6 +1,5 @@
 package com.didww.sdk.repository;
 
-import com.didww.sdk.exception.DidwwApiException;
 import com.didww.sdk.exception.DidwwClientException;
 import com.didww.sdk.http.QueryParams;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,7 +30,7 @@ public class SingletonRepository<T> extends ReadOnlyRepository<T> {
             byte[] body = getResponseBody(response);
             JSONAPIDocument<T> document = converter.readDocument(body, resourceClass);
             return new ApiResponse<>(document.get(), extractMeta(document));
-        } catch (DidwwApiException e) {
+        } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new DidwwClientException("Failed to find " + endpoint, e);

--- a/src/main/java/com/didww/sdk/resource/CapacityPool.java
+++ b/src/main/java/com/didww/sdk/resource/CapacityPool.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Type("capacity_pools")
@@ -13,7 +14,7 @@ public class CapacityPool extends BaseResource {
     private String name;
 
     @JsonProperty(value = "renew_date", access = JsonProperty.Access.WRITE_ONLY)
-    private String renewDate;
+    private LocalDate renewDate;
 
     @JsonProperty("total_channels_count")
     private Integer totalChannelsCount;
@@ -49,7 +50,7 @@ public class CapacityPool extends BaseResource {
         return name;
     }
 
-    public String getRenewDate() {
+    public LocalDate getRenewDate() {
         return renewDate;
     }
 

--- a/src/main/java/com/didww/sdk/resource/EncryptedFile.java
+++ b/src/main/java/com/didww/sdk/resource/EncryptedFile.java
@@ -14,7 +14,7 @@ public class EncryptedFile extends BaseResource {
     @JsonProperty("expire_at")
     private OffsetDateTime expireAt;
 
-    @JsonProperty("created_at")
+    @JsonProperty(value = "created_at", access = JsonProperty.Access.WRITE_ONLY)
     private OffsetDateTime createdAt;
 
     public String getDescription() {

--- a/src/main/java/com/didww/sdk/resource/Identity.java
+++ b/src/main/java/com/didww/sdk/resource/Identity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -23,7 +24,7 @@ public class Identity extends BaseResource {
     private String idNumber;
 
     @JsonProperty("birth_date")
-    private String birthDate;
+    private LocalDate birthDate;
 
     @JsonProperty("company_name")
     private String companyName;
@@ -96,11 +97,11 @@ public class Identity extends BaseResource {
         this.idNumber = idNumber;
     }
 
-    public String getBirthDate() {
+    public LocalDate getBirthDate() {
         return birthDate;
     }
 
-    public void setBirthDate(String birthDate) {
+    public void setBirthDate(LocalDate birthDate) {
         this.birthDate = birthDate;
     }
 

--- a/src/test/java/com/didww/sdk/resource/AvailableDidTest.java
+++ b/src/test/java/com/didww/sdk/resource/AvailableDidTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/BalanceTest.java
+++ b/src/test/java/com/didww/sdk/resource/BalanceTest.java
@@ -1,11 +1,8 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
-import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 

--- a/src/test/java/com/didww/sdk/resource/CityTest.java
+++ b/src/test/java/com/didww/sdk/resource/CityTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/CountryTest.java
+++ b/src/test/java/com/didww/sdk/resource/CountryTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/DidGroupTest.java
+++ b/src/test/java/com/didww/sdk/resource/DidGroupTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/DidGroupTypeTest.java
+++ b/src/test/java/com/didww/sdk/resource/DidGroupTypeTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/DidTest.java
+++ b/src/test/java/com/didww/sdk/resource/DidTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/IdentityTest.java
+++ b/src/test/java/com/didww/sdk/resource/IdentityTest.java
@@ -4,6 +4,7 @@ import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -47,7 +48,7 @@ class IdentityTest extends BaseTest {
         identity.setLastName("Doe");
         identity.setPhoneNumber("123456789");
         identity.setIdNumber("ABC1234");
-        identity.setBirthDate("1970-01-01");
+        identity.setBirthDate(LocalDate.of(1970, 1, 1));
         identity.setCompanyName("Test Company Limited");
         identity.setCompanyRegNumber("543221");
         identity.setVatId("GB1234");

--- a/src/test/java/com/didww/sdk/resource/PopTest.java
+++ b/src/test/java/com/didww/sdk/resource/PopTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/RegionTest.java
+++ b/src/test/java/com/didww/sdk/resource/RegionTest.java
@@ -1,9 +1,7 @@
 package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
-import com.didww.sdk.resource.*;
 import com.didww.sdk.repository.ApiResponse;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/didww/sdk/resource/VoiceOutTrunkTest.java
+++ b/src/test/java/com/didww/sdk/resource/VoiceOutTrunkTest.java
@@ -4,7 +4,6 @@ import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 


### PR DESCRIPTION
- Extract PolymorphicJsonHelper for shared type/attributes ser/deser
- Remove duplicate TYPE_MAP from deserializers, reuse from base classes
- Remove unused no-arg DidwwResourceConverter.create()
- Remove unused imports across 12 files
- Add WRITE_ONLY to EncryptedFile.createdAt
- Change Identity.birthDate and CapacityPool.renewDate to LocalDate
- Simplify QueryParams.encode() for Java 11+ (no dead catch block)
- Use StandardCharsets.UTF_8 in RequestValidator
- Simplify repository exception handling (catch RuntimeException)
- Remove redundant catch-rethrow in DidwwClient.downloadExport