### PR TITLE
Add Java enums for API constant fields

### DIFF
--- a/src/main/java/com/didww/sdk/converter/DidwwResourceConverter.java
+++ b/src/main/java/com/didww/sdk/converter/DidwwResourceConverter.java
@@ -52,7 +52,9 @@ public class DidwwResourceConverter {
     public static ObjectMapper createObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new EnumModule());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);

--- a/src/main/java/com/didww/sdk/converter/EnumModule.java
+++ b/src/main/java/com/didww/sdk/converter/EnumModule.java
@@ -1,0 +1,53 @@
+package com.didww.sdk.converter;
+
+import com.didww.sdk.resource.enums.IntEnum;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+public class EnumModule extends SimpleModule {
+
+    public EnumModule() {
+        super("EnumModule");
+        setDeserializers(new SimpleDeserializers() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public JsonDeserializer<?> findEnumDeserializer(Class<?> type,
+                    DeserializationConfig config, BeanDescription beanDesc) {
+                if (IntEnum.class.isAssignableFrom(type)) {
+                    return new IntEnumDeserializer((Class<? extends Enum<?>>) type);
+                }
+                return null;
+            }
+        });
+    }
+
+    private static class IntEnumDeserializer extends JsonDeserializer<Enum<?>> {
+        private final Class<? extends Enum<?>> enumType;
+
+        IntEnumDeserializer(Class<? extends Enum<?>> enumType) {
+            this.enumType = enumType;
+        }
+
+        @Override
+        public Enum<?> deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+            int value = p.getIntValue();
+            for (Enum<?> constant : enumType.getEnumConstants()) {
+                if (((IntEnum) constant).getValue() == value) {
+                    return constant;
+                }
+            }
+            if (ctx.isEnabled(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)) {
+                return null;
+            }
+            throw new IllegalArgumentException("Unknown " + enumType.getSimpleName() + ": " + value);
+        }
+    }
+}

--- a/src/main/java/com/didww/sdk/resource/AddressVerification.java
+++ b/src/main/java/com/didww/sdk/resource/AddressVerification.java
@@ -1,5 +1,7 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.AddressVerificationStatus;
+import com.didww.sdk.resource.enums.CallbackMethod;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -17,10 +19,10 @@ public class AddressVerification extends BaseResource {
     private String callbackUrl;
 
     @JsonProperty("callback_method")
-    private String callbackMethod;
+    private CallbackMethod callbackMethod;
 
     @JsonProperty(value = "status", access = JsonProperty.Access.WRITE_ONLY)
-    private String status;
+    private AddressVerificationStatus status;
 
     @JsonProperty(value = "reject_reasons", access = JsonProperty.Access.WRITE_ONLY)
     private List<String> rejectReasons;
@@ -50,15 +52,15 @@ public class AddressVerification extends BaseResource {
         this.callbackUrl = callbackUrl;
     }
 
-    public String getCallbackMethod() {
+    public CallbackMethod getCallbackMethod() {
         return callbackMethod;
     }
 
-    public void setCallbackMethod(String callbackMethod) {
+    public void setCallbackMethod(CallbackMethod callbackMethod) {
         this.callbackMethod = callbackMethod;
     }
 
-    public String getStatus() {
+    public AddressVerificationStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/com/didww/sdk/resource/DidGroup.java
+++ b/src/main/java/com/didww/sdk/resource/DidGroup.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.Feature;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -16,7 +17,7 @@ public class DidGroup extends BaseResource {
     private String prefix;
 
     @JsonProperty("features")
-    private List<String> features;
+    private List<Feature> features;
 
     @JsonProperty("is_metered")
     private Boolean isMetered;
@@ -47,7 +48,7 @@ public class DidGroup extends BaseResource {
         return prefix;
     }
 
-    public List<String> getFeatures() {
+    public List<Feature> getFeatures() {
         return features;
     }
 

--- a/src/main/java/com/didww/sdk/resource/Export.java
+++ b/src/main/java/com/didww/sdk/resource/Export.java
@@ -1,5 +1,8 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.CallbackMethod;
+import com.didww.sdk.resource.enums.ExportStatus;
+import com.didww.sdk.resource.enums.ExportType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Type;
 
@@ -10,7 +13,7 @@ import java.util.Map;
 public class Export extends BaseResource {
 
     @JsonProperty("export_type")
-    private String exportType;
+    private ExportType exportType;
 
     @JsonProperty(value = "url", access = JsonProperty.Access.WRITE_ONLY)
     private String url;
@@ -19,10 +22,10 @@ public class Export extends BaseResource {
     private String callbackUrl;
 
     @JsonProperty("callback_method")
-    private String callbackMethod;
+    private CallbackMethod callbackMethod;
 
     @JsonProperty(value = "status", access = JsonProperty.Access.WRITE_ONLY)
-    private String status;
+    private ExportStatus status;
 
     @JsonProperty("filters")
     private Map<String, Object> filters;
@@ -30,11 +33,11 @@ public class Export extends BaseResource {
     @JsonProperty(value = "created_at", access = JsonProperty.Access.WRITE_ONLY)
     private OffsetDateTime createdAt;
 
-    public String getExportType() {
+    public ExportType getExportType() {
         return exportType;
     }
 
-    public void setExportType(String exportType) {
+    public void setExportType(ExportType exportType) {
         this.exportType = exportType;
     }
 
@@ -50,15 +53,15 @@ public class Export extends BaseResource {
         this.callbackUrl = callbackUrl;
     }
 
-    public String getCallbackMethod() {
+    public CallbackMethod getCallbackMethod() {
         return callbackMethod;
     }
 
-    public void setCallbackMethod(String callbackMethod) {
+    public void setCallbackMethod(CallbackMethod callbackMethod) {
         this.callbackMethod = callbackMethod;
     }
 
-    public String getStatus() {
+    public ExportStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/com/didww/sdk/resource/Identity.java
+++ b/src/main/java/com/didww/sdk/resource/Identity.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.IdentityType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -42,7 +43,7 @@ public class Identity extends BaseResource {
     private String personalTaxId;
 
     @JsonProperty("identity_type")
-    private String identityType;
+    private IdentityType identityType;
 
     @JsonProperty("external_reference_id")
     private String externalReferenceId;
@@ -145,11 +146,11 @@ public class Identity extends BaseResource {
         this.personalTaxId = personalTaxId;
     }
 
-    public String getIdentityType() {
+    public IdentityType getIdentityType() {
         return identityType;
     }
 
-    public void setIdentityType(String identityType) {
+    public void setIdentityType(IdentityType identityType) {
         this.identityType = identityType;
     }
 

--- a/src/main/java/com/didww/sdk/resource/Order.java
+++ b/src/main/java/com/didww/sdk/resource/Order.java
@@ -1,5 +1,7 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.CallbackMethod;
+import com.didww.sdk.resource.enums.OrderStatus;
 import com.didww.sdk.converter.OrderItemDeserializer;
 import com.didww.sdk.converter.OrderItemSerializer;
 import com.didww.sdk.resource.orderitem.OrderItem;
@@ -18,7 +20,7 @@ public class Order extends BaseResource {
     private Double amount;
 
     @JsonProperty(value = "status", access = JsonProperty.Access.WRITE_ONLY)
-    private String status;
+    private OrderStatus status;
 
     @JsonProperty(value = "description", access = JsonProperty.Access.WRITE_ONLY)
     private String description;
@@ -33,7 +35,7 @@ public class Order extends BaseResource {
     private String callbackUrl;
 
     @JsonProperty("callback_method")
-    private String callbackMethod;
+    private CallbackMethod callbackMethod;
 
     @JsonProperty("allow_back_ordering")
     private Boolean allowBackOrdering;
@@ -47,7 +49,7 @@ public class Order extends BaseResource {
         return amount;
     }
 
-    public String getStatus() {
+    public OrderStatus getStatus() {
         return status;
     }
 
@@ -71,11 +73,11 @@ public class Order extends BaseResource {
         this.callbackUrl = callbackUrl;
     }
 
-    public String getCallbackMethod() {
+    public CallbackMethod getCallbackMethod() {
         return callbackMethod;
     }
 
-    public void setCallbackMethod(String callbackMethod) {
+    public void setCallbackMethod(CallbackMethod callbackMethod) {
         this.callbackMethod = callbackMethod;
     }
 

--- a/src/main/java/com/didww/sdk/resource/Requirement.java
+++ b/src/main/java/com/didww/sdk/resource/Requirement.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.IdentityType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -10,7 +11,7 @@ import java.util.List;
 public class Requirement extends BaseResource {
 
     @JsonProperty("identity_type")
-    private String identityType;
+    private IdentityType identityType;
 
     @JsonProperty("personal_area_level")
     private String personalAreaLevel;
@@ -69,7 +70,7 @@ public class Requirement extends BaseResource {
     @Relationship("address_proof_types")
     private List<ProofType> addressProofTypes;
 
-    public String getIdentityType() {
+    public IdentityType getIdentityType() {
         return identityType;
     }
 

--- a/src/main/java/com/didww/sdk/resource/VoiceInTrunk.java
+++ b/src/main/java/com/didww/sdk/resource/VoiceInTrunk.java
@@ -3,6 +3,7 @@ package com.didww.sdk.resource;
 import com.didww.sdk.converter.TrunkConfigurationDeserializer;
 import com.didww.sdk.converter.TrunkConfigurationSerializer;
 import com.didww.sdk.resource.configuration.TrunkConfiguration;
+import com.didww.sdk.resource.enums.CliFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -24,7 +25,7 @@ public class VoiceInTrunk extends BaseResource {
     private Integer weight;
 
     @JsonProperty("cli_format")
-    private String cliFormat;
+    private CliFormat cliFormat;
 
     @JsonProperty("cli_prefix")
     private String cliPrefix;
@@ -76,11 +77,11 @@ public class VoiceInTrunk extends BaseResource {
         this.weight = weight;
     }
 
-    public String getCliFormat() {
+    public CliFormat getCliFormat() {
         return cliFormat;
     }
 
-    public void setCliFormat(String cliFormat) {
+    public void setCliFormat(CliFormat cliFormat) {
         this.cliFormat = cliFormat;
     }
 

--- a/src/main/java/com/didww/sdk/resource/VoiceOutTrunk.java
+++ b/src/main/java/com/didww/sdk/resource/VoiceOutTrunk.java
@@ -1,5 +1,9 @@
 package com.didww.sdk.resource;
 
+import com.didww.sdk.resource.enums.DefaultDstAction;
+import com.didww.sdk.resource.enums.MediaEncryptionMode;
+import com.didww.sdk.resource.enums.OnCliMismatchAction;
+import com.didww.sdk.resource.enums.VoiceOutTrunkStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
@@ -17,7 +21,7 @@ public class VoiceOutTrunk extends BaseResource {
     private List<String> allowedSipIps;
 
     @JsonProperty("on_cli_mismatch_action")
-    private String onCliMismatchAction;
+    private OnCliMismatchAction onCliMismatchAction;
 
     @JsonProperty("allowed_rtp_ips")
     private List<String> allowedRtpIps;
@@ -26,7 +30,7 @@ public class VoiceOutTrunk extends BaseResource {
     private Boolean allowAnyDidAsCli;
 
     @JsonProperty("status")
-    private String status;
+    private VoiceOutTrunkStatus status;
 
     @JsonProperty("capacity_limit")
     private Integer capacityLimit;
@@ -35,10 +39,10 @@ public class VoiceOutTrunk extends BaseResource {
     private String thresholdAmount;
 
     @JsonProperty("media_encryption_mode")
-    private String mediaEncryptionMode;
+    private MediaEncryptionMode mediaEncryptionMode;
 
     @JsonProperty("default_dst_action")
-    private String defaultDstAction;
+    private DefaultDstAction defaultDstAction;
 
     @JsonProperty("dst_prefixes")
     private List<String> dstPrefixes;
@@ -86,11 +90,11 @@ public class VoiceOutTrunk extends BaseResource {
         this.allowedSipIps = allowedSipIps;
     }
 
-    public String getOnCliMismatchAction() {
+    public OnCliMismatchAction getOnCliMismatchAction() {
         return onCliMismatchAction;
     }
 
-    public void setOnCliMismatchAction(String onCliMismatchAction) {
+    public void setOnCliMismatchAction(OnCliMismatchAction onCliMismatchAction) {
         this.onCliMismatchAction = onCliMismatchAction;
     }
 
@@ -110,7 +114,7 @@ public class VoiceOutTrunk extends BaseResource {
         this.allowAnyDidAsCli = allowAnyDidAsCli;
     }
 
-    public String getStatus() {
+    public VoiceOutTrunkStatus getStatus() {
         return status;
     }
 
@@ -130,19 +134,19 @@ public class VoiceOutTrunk extends BaseResource {
         this.thresholdAmount = thresholdAmount;
     }
 
-    public String getMediaEncryptionMode() {
+    public MediaEncryptionMode getMediaEncryptionMode() {
         return mediaEncryptionMode;
     }
 
-    public void setMediaEncryptionMode(String mediaEncryptionMode) {
+    public void setMediaEncryptionMode(MediaEncryptionMode mediaEncryptionMode) {
         this.mediaEncryptionMode = mediaEncryptionMode;
     }
 
-    public String getDefaultDstAction() {
+    public DefaultDstAction getDefaultDstAction() {
         return defaultDstAction;
     }
 
-    public void setDefaultDstAction(String defaultDstAction) {
+    public void setDefaultDstAction(DefaultDstAction defaultDstAction) {
         this.defaultDstAction = defaultDstAction;
     }
 

--- a/src/main/java/com/didww/sdk/resource/configuration/H323Configuration.java
+++ b/src/main/java/com/didww/sdk/resource/configuration/H323Configuration.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource.configuration;
 
+import com.didww.sdk.resource.enums.Codec;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -17,7 +18,7 @@ public class H323Configuration extends TrunkConfiguration {
     private Integer port;
 
     @JsonProperty("codec_ids")
-    private List<Integer> codecIds;
+    private List<Codec> codecIds;
 
     @Override
     @JsonIgnore
@@ -49,11 +50,11 @@ public class H323Configuration extends TrunkConfiguration {
         this.port = port;
     }
 
-    public List<Integer> getCodecIds() {
+    public List<Codec> getCodecIds() {
         return codecIds;
     }
 
-    public void setCodecIds(List<Integer> codecIds) {
+    public void setCodecIds(List<Codec> codecIds) {
         this.codecIds = codecIds;
     }
 }

--- a/src/main/java/com/didww/sdk/resource/configuration/Iax2Configuration.java
+++ b/src/main/java/com/didww/sdk/resource/configuration/Iax2Configuration.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource.configuration;
 
+import com.didww.sdk.resource.enums.Codec;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -17,7 +18,7 @@ public class Iax2Configuration extends TrunkConfiguration {
     private Integer port;
 
     @JsonProperty("codec_ids")
-    private List<Integer> codecIds;
+    private List<Codec> codecIds;
 
     @JsonProperty("auth_user")
     private String authUser;
@@ -55,11 +56,11 @@ public class Iax2Configuration extends TrunkConfiguration {
         this.port = port;
     }
 
-    public List<Integer> getCodecIds() {
+    public List<Codec> getCodecIds() {
         return codecIds;
     }
 
-    public void setCodecIds(List<Integer> codecIds) {
+    public void setCodecIds(List<Codec> codecIds) {
         this.codecIds = codecIds;
     }
 

--- a/src/main/java/com/didww/sdk/resource/configuration/SipConfiguration.java
+++ b/src/main/java/com/didww/sdk/resource/configuration/SipConfiguration.java
@@ -1,5 +1,6 @@
 package com.didww.sdk.resource.configuration;
 
+import com.didww.sdk.resource.enums.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -17,13 +18,13 @@ public class SipConfiguration extends TrunkConfiguration {
     private Integer port;
 
     @JsonProperty("codec_ids")
-    private List<Integer> codecIds;
+    private List<Codec> codecIds;
 
     @JsonProperty("rx_dtmf_format_id")
-    private Integer rxDtmfFormatId;
+    private RxDtmfFormat rxDtmfFormatId;
 
     @JsonProperty("tx_dtmf_format_id")
-    private Integer txDtmfFormatId;
+    private TxDtmfFormat txDtmfFormatId;
 
     @JsonProperty("resolve_ruri")
     private Boolean resolveRuri;
@@ -59,7 +60,7 @@ public class SipConfiguration extends TrunkConfiguration {
     private Integer sstSessionExpires;
 
     @JsonProperty("sst_refresh_method_id")
-    private Integer sstRefreshMethodId;
+    private SstRefreshMethod sstRefreshMethodId;
 
     @JsonProperty("sip_timer_b")
     private Integer sipTimerB;
@@ -77,7 +78,13 @@ public class SipConfiguration extends TrunkConfiguration {
     private List<Integer> reroutingDisconnectCodeIds;
 
     @JsonProperty("transport_protocol_id")
-    private Integer transportProtocolId;
+    private TransportProtocol transportProtocolId;
+
+    @JsonProperty("media_encryption_mode")
+    private MediaEncryptionMode mediaEncryptionMode;
+
+    @JsonProperty("stir_shaken_mode")
+    private StirShakenMode stirShakenMode;
 
     @JsonProperty("max_transfers")
     private Integer maxTransfers;
@@ -115,27 +122,27 @@ public class SipConfiguration extends TrunkConfiguration {
         this.port = port;
     }
 
-    public List<Integer> getCodecIds() {
+    public List<Codec> getCodecIds() {
         return codecIds;
     }
 
-    public void setCodecIds(List<Integer> codecIds) {
+    public void setCodecIds(List<Codec> codecIds) {
         this.codecIds = codecIds;
     }
 
-    public Integer getRxDtmfFormatId() {
+    public RxDtmfFormat getRxDtmfFormatId() {
         return rxDtmfFormatId;
     }
 
-    public void setRxDtmfFormatId(Integer rxDtmfFormatId) {
+    public void setRxDtmfFormatId(RxDtmfFormat rxDtmfFormatId) {
         this.rxDtmfFormatId = rxDtmfFormatId;
     }
 
-    public Integer getTxDtmfFormatId() {
+    public TxDtmfFormat getTxDtmfFormatId() {
         return txDtmfFormatId;
     }
 
-    public void setTxDtmfFormatId(Integer txDtmfFormatId) {
+    public void setTxDtmfFormatId(TxDtmfFormat txDtmfFormatId) {
         this.txDtmfFormatId = txDtmfFormatId;
     }
 
@@ -227,11 +234,11 @@ public class SipConfiguration extends TrunkConfiguration {
         this.sstSessionExpires = sstSessionExpires;
     }
 
-    public Integer getSstRefreshMethodId() {
+    public SstRefreshMethod getSstRefreshMethodId() {
         return sstRefreshMethodId;
     }
 
-    public void setSstRefreshMethodId(Integer sstRefreshMethodId) {
+    public void setSstRefreshMethodId(SstRefreshMethod sstRefreshMethodId) {
         this.sstRefreshMethodId = sstRefreshMethodId;
     }
 
@@ -275,12 +282,28 @@ public class SipConfiguration extends TrunkConfiguration {
         this.reroutingDisconnectCodeIds = reroutingDisconnectCodeIds;
     }
 
-    public Integer getTransportProtocolId() {
+    public TransportProtocol getTransportProtocolId() {
         return transportProtocolId;
     }
 
-    public void setTransportProtocolId(Integer transportProtocolId) {
+    public void setTransportProtocolId(TransportProtocol transportProtocolId) {
         this.transportProtocolId = transportProtocolId;
+    }
+
+    public MediaEncryptionMode getMediaEncryptionMode() {
+        return mediaEncryptionMode;
+    }
+
+    public void setMediaEncryptionMode(MediaEncryptionMode mediaEncryptionMode) {
+        this.mediaEncryptionMode = mediaEncryptionMode;
+    }
+
+    public StirShakenMode getStirShakenMode() {
+        return stirShakenMode;
+    }
+
+    public void setStirShakenMode(StirShakenMode stirShakenMode) {
+        this.stirShakenMode = stirShakenMode;
     }
 
     public Integer getMaxTransfers() {

--- a/src/main/java/com/didww/sdk/resource/enums/AddressVerificationStatus.java
+++ b/src/main/java/com/didww/sdk/resource/enums/AddressVerificationStatus.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum AddressVerificationStatus {
+    @JsonProperty("Pending") PENDING,
+    @JsonProperty("Approved") APPROVED,
+    @JsonProperty("Rejected") REJECTED;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/CallbackMethod.java
+++ b/src/main/java/com/didww/sdk/resource/enums/CallbackMethod.java
@@ -1,0 +1,8 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum CallbackMethod {
+    @JsonProperty("POST") POST,
+    @JsonProperty("GET") GET;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/CliFormat.java
+++ b/src/main/java/com/didww/sdk/resource/enums/CliFormat.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum CliFormat {
+    @JsonProperty("raw") RAW,
+    @JsonProperty("e164") E164,
+    @JsonProperty("local") LOCAL;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/Codec.java
+++ b/src/main/java/com/didww/sdk/resource/enums/Codec.java
@@ -1,0 +1,19 @@
+package com.didww.sdk.resource.enums;
+
+public enum Codec implements IntEnum {
+    TELEPHONE_EVENT(6),
+    G723(7),
+    G729(8),
+    PCMU(9),
+    PCMA(10),
+    SPEEX(12),
+    GSM(13),
+    G726_32(14),
+    G721(15),
+    G726_24(16),
+    G726_40(17),
+    G726_16(18),
+    L16(19);
+
+    Codec(int value) { IntEnum.register(this, value); }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/DefaultDstAction.java
+++ b/src/main/java/com/didww/sdk/resource/enums/DefaultDstAction.java
@@ -1,0 +1,8 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum DefaultDstAction {
+    @JsonProperty("allow_all") ALLOW_ALL,
+    @JsonProperty("reject_all") REJECT_ALL;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/ExportStatus.java
+++ b/src/main/java/com/didww/sdk/resource/enums/ExportStatus.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ExportStatus {
+    @JsonProperty("Pending") PENDING,
+    @JsonProperty("Processing") PROCESSING,
+    @JsonProperty("Completed") COMPLETED;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/ExportType.java
+++ b/src/main/java/com/didww/sdk/resource/enums/ExportType.java
@@ -1,0 +1,8 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ExportType {
+    @JsonProperty("cdr_in") CDR_IN,
+    @JsonProperty("cdr_out") CDR_OUT;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/Feature.java
+++ b/src/main/java/com/didww/sdk/resource/enums/Feature.java
@@ -1,0 +1,13 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Feature {
+    @JsonProperty("voice") VOICE,
+    @JsonProperty("voice_in") VOICE_IN,
+    @JsonProperty("voice_out") VOICE_OUT,
+    @JsonProperty("t38") T38,
+    @JsonProperty("sms") SMS,
+    @JsonProperty("sms_in") SMS_IN,
+    @JsonProperty("sms_out") SMS_OUT;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/IdentityType.java
+++ b/src/main/java/com/didww/sdk/resource/enums/IdentityType.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum IdentityType {
+    @JsonProperty("Personal") PERSONAL,
+    @JsonProperty("Business") BUSINESS,
+    @JsonProperty("Any") ANY;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/IntEnum.java
+++ b/src/main/java/com/didww/sdk/resource/enums/IntEnum.java
@@ -1,0 +1,19 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public interface IntEnum {
+    Map<IntEnum, Integer> REGISTRY = new ConcurrentHashMap<>();
+
+    static void register(IntEnum instance, int value) {
+        REGISTRY.put(instance, value);
+    }
+
+    @JsonValue
+    default int getValue() {
+        return REGISTRY.get(this);
+    }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/MediaEncryptionMode.java
+++ b/src/main/java/com/didww/sdk/resource/enums/MediaEncryptionMode.java
@@ -1,0 +1,10 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MediaEncryptionMode {
+    @JsonProperty("disabled") DISABLED,
+    @JsonProperty("srtp_sdes") SRTP_SDES,
+    @JsonProperty("srtp_dtls") SRTP_DTLS,
+    @JsonProperty("zrtp") ZRTP;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/OnCliMismatchAction.java
+++ b/src/main/java/com/didww/sdk/resource/enums/OnCliMismatchAction.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum OnCliMismatchAction {
+    @JsonProperty("send_original_cli") SEND_ORIGINAL_CLI,
+    @JsonProperty("reject_call") REJECT_CALL,
+    @JsonProperty("replace_cli") REPLACE_CLI;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/OrderStatus.java
+++ b/src/main/java/com/didww/sdk/resource/enums/OrderStatus.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum OrderStatus {
+    @JsonProperty("Pending") PENDING,
+    @JsonProperty("Canceled") CANCELED,
+    @JsonProperty("Completed") COMPLETED;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/RxDtmfFormat.java
+++ b/src/main/java/com/didww/sdk/resource/enums/RxDtmfFormat.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+public enum RxDtmfFormat implements IntEnum {
+    RFC_2833(1),
+    SIP_INFO(2),
+    RFC_2833_OR_SIP_INFO(3);
+
+    RxDtmfFormat(int value) { IntEnum.register(this, value); }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/SstRefreshMethod.java
+++ b/src/main/java/com/didww/sdk/resource/enums/SstRefreshMethod.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+public enum SstRefreshMethod implements IntEnum {
+    INVITE(1),
+    UPDATE(2),
+    UPDATE_FALLBACK_INVITE(3);
+
+    SstRefreshMethod(int value) { IntEnum.register(this, value); }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/StirShakenMode.java
+++ b/src/main/java/com/didww/sdk/resource/enums/StirShakenMode.java
@@ -1,0 +1,11 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum StirShakenMode {
+    @JsonProperty("disabled") DISABLED,
+    @JsonProperty("original") ORIGINAL,
+    @JsonProperty("pai") PAI,
+    @JsonProperty("original_pai") ORIGINAL_PAI,
+    @JsonProperty("verstat") VERSTAT;
+}

--- a/src/main/java/com/didww/sdk/resource/enums/TransportProtocol.java
+++ b/src/main/java/com/didww/sdk/resource/enums/TransportProtocol.java
@@ -1,0 +1,9 @@
+package com.didww.sdk.resource.enums;
+
+public enum TransportProtocol implements IntEnum {
+    UDP(1),
+    TCP(2),
+    TLS(3);
+
+    TransportProtocol(int value) { IntEnum.register(this, value); }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/TxDtmfFormat.java
+++ b/src/main/java/com/didww/sdk/resource/enums/TxDtmfFormat.java
@@ -1,0 +1,10 @@
+package com.didww.sdk.resource.enums;
+
+public enum TxDtmfFormat implements IntEnum {
+    DISABLED(1),
+    RFC_2833(2),
+    SIP_INFO_RELAY(3),
+    SIP_INFO_DTMF(4);
+
+    TxDtmfFormat(int value) { IntEnum.register(this, value); }
+}

--- a/src/main/java/com/didww/sdk/resource/enums/VoiceOutTrunkStatus.java
+++ b/src/main/java/com/didww/sdk/resource/enums/VoiceOutTrunkStatus.java
@@ -1,0 +1,8 @@
+package com.didww.sdk.resource.enums;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum VoiceOutTrunkStatus {
+    @JsonProperty("active") ACTIVE,
+    @JsonProperty("blocked") BLOCKED;
+}

--- a/src/test/java/com/didww/sdk/resource/AddressVerificationTest.java
+++ b/src/test/java/com/didww/sdk/resource/AddressVerificationTest.java
@@ -2,6 +2,8 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.AddressVerificationStatus;
+import com.didww.sdk.resource.enums.CallbackMethod;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -26,8 +28,8 @@ class AddressVerificationTest extends BaseTest {
         assertThat(verifications).isNotEmpty();
         assertThat(verifications.get(0).getId()).isEqualTo("aaf2180a-3f2b-4427-888f-3d00f872014e");
         assertThat(verifications.get(0).getCallbackUrl()).isEqualTo("http://example.com");
-        assertThat(verifications.get(0).getCallbackMethod()).isEqualTo("GET");
-        assertThat(verifications.get(0).getStatus()).isEqualTo("Pending");
+        assertThat(verifications.get(0).getCallbackMethod()).isEqualTo(CallbackMethod.GET);
+        assertThat(verifications.get(0).getStatus()).isEqualTo(AddressVerificationStatus.PENDING);
     }
 
     @Test
@@ -47,7 +49,7 @@ class AddressVerificationTest extends BaseTest {
 
         AddressVerification verification = new AddressVerification();
         verification.setCallbackUrl("http://example.com");
-        verification.setCallbackMethod("GET");
+        verification.setCallbackMethod(CallbackMethod.GET);
         verification.setAddress(address);
         verification.setDids(Collections.singletonList(did));
 
@@ -56,7 +58,7 @@ class AddressVerificationTest extends BaseTest {
 
         assertThat(created.getId()).isEqualTo("78182ef2-8377-41cd-89e1-26e8266c9c94");
         assertThat(created.getCallbackUrl()).isEqualTo("http://example.com");
-        assertThat(created.getCallbackMethod()).isEqualTo("GET");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getCallbackMethod()).isEqualTo(CallbackMethod.GET);
+        assertThat(created.getStatus()).isEqualTo(AddressVerificationStatus.PENDING);
     }
 }

--- a/src/test/java/com/didww/sdk/resource/ExportTest.java
+++ b/src/test/java/com/didww/sdk/resource/ExportTest.java
@@ -2,6 +2,8 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.ExportStatus;
+import com.didww.sdk.resource.enums.ExportType;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
@@ -28,8 +30,8 @@ class ExportTest extends BaseTest {
 
         Export first = exports.get(0);
         assertThat(first.getId()).isEqualTo("da15f006-5da4-45ca-b0df-735baeadf423");
-        assertThat(first.getStatus()).isEqualTo("Completed");
-        assertThat(first.getExportType()).isEqualTo("cdr_in");
+        assertThat(first.getStatus()).isEqualTo(ExportStatus.COMPLETED);
+        assertThat(first.getExportType()).isEqualTo(ExportType.CDR_IN);
     }
 
     @Test
@@ -47,14 +49,14 @@ class ExportTest extends BaseTest {
         filters.put("month", "01");
 
         Export export = new Export();
-        export.setExportType("cdr_in");
+        export.setExportType(ExportType.CDR_IN);
         export.setFilters(filters);
 
         ApiResponse<Export> response = client.exports().create(export);
         Export created = response.getData();
 
         assertThat(created.getId()).isEqualTo("da15f006-5da4-45ca-b0df-735baeadf423");
-        assertThat(created.getStatus()).isEqualTo("Pending");
-        assertThat(created.getExportType()).isEqualTo("cdr_in");
+        assertThat(created.getStatus()).isEqualTo(ExportStatus.PENDING);
+        assertThat(created.getExportType()).isEqualTo(ExportType.CDR_IN);
     }
 }

--- a/src/test/java/com/didww/sdk/resource/IdentityTest.java
+++ b/src/test/java/com/didww/sdk/resource/IdentityTest.java
@@ -2,6 +2,7 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.IdentityType;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -28,7 +29,7 @@ class IdentityTest extends BaseTest {
         assertThat(identities.get(0).getId()).isEqualTo("5e9df058-50d2-4e34-b0d4-d1746b86f41a");
         assertThat(identities.get(0).getFirstName()).isEqualTo("John");
         assertThat(identities.get(0).getLastName()).isEqualTo("Doe");
-        assertThat(identities.get(0).getIdentityType()).isEqualTo("Personal");
+        assertThat(identities.get(0).getIdentityType()).isEqualTo(IdentityType.PERSONAL);
     }
 
     @Test
@@ -54,7 +55,7 @@ class IdentityTest extends BaseTest {
         identity.setVatId("GB1234");
         identity.setDescription("test identity");
         identity.setPersonalTaxId("987654321");
-        identity.setIdentityType("Business");
+        identity.setIdentityType(IdentityType.BUSINESS);
         identity.setExternalReferenceId("111");
         identity.setCountry(country);
 
@@ -63,7 +64,7 @@ class IdentityTest extends BaseTest {
 
         assertThat(created.getId()).isEqualTo("e96ae7d1-11d5-42bc-a5c5-211f3c3788ae");
         assertThat(created.getFirstName()).isEqualTo("John");
-        assertThat(created.getIdentityType()).isEqualTo("Business");
+        assertThat(created.getIdentityType()).isEqualTo(IdentityType.BUSINESS);
         assertThat(created.getVerified()).isFalse();
     }
 

--- a/src/test/java/com/didww/sdk/resource/OrderTest.java
+++ b/src/test/java/com/didww/sdk/resource/OrderTest.java
@@ -2,6 +2,8 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.CallbackMethod;
+import com.didww.sdk.resource.enums.OrderStatus;
 import com.didww.sdk.resource.orderitem.AvailableDidOrderItem;
 import com.didww.sdk.resource.orderitem.CapacityOrderItem;
 import com.didww.sdk.resource.orderitem.DidOrderItem;
@@ -28,7 +30,7 @@ class OrderTest extends BaseTest {
         Order order = response.getData();
 
         assertThat(order.getId()).isEqualTo("9df11dac-9d83-448c-8866-19c998be33db");
-        assertThat(order.getStatus()).isEqualTo("Completed");
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
         assertThat(order.getDescription()).isEqualTo("Payment processing fee");
         assertThat(order.getReference()).isEqualTo("SPT-474057");
         assertThat(order.getItems()).isNotEmpty();
@@ -59,7 +61,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("5da18706-be9f-49b0-aeec-0480aacd49ad");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getDescription()).isEqualTo("DID");
         assertThat(created.getItems()).hasSize(2);
     }
@@ -86,7 +88,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("9b9f2121-8d9e-4aa8-9754-dbaf6f695fd6");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getDescription()).isEqualTo("DID");
         assertThat(created.getItems()).hasSize(1);
     }
@@ -111,7 +113,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("9b9f2121-8d9e-4aa8-9754-dbaf6f695fd6");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getDescription()).isEqualTo("DID");
         assertThat(created.getItems()).hasSize(1);
         assertThat(created.getItems().get(0)).isInstanceOf(DidOrderItem.class);
@@ -137,7 +139,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("a9a7ff2d-d634-4545-bf28-dfda92d1c723");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getDescription()).isEqualTo("DID");
         assertThat(created.getItems()).hasSize(1);
         assertThat(created.getItems().get(0)).isInstanceOf(DidOrderItem.class);
@@ -163,7 +165,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("68a46dd5-d405-4283-b7a5-62503267e9f8");
-        assertThat(created.getStatus()).isEqualTo("Completed");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.COMPLETED);
         assertThat(created.getDescription()).isEqualTo("Capacity");
         assertThat(created.getItems()).hasSize(1);
         assertThat(created.getItems().get(0)).isInstanceOf(CapacityOrderItem.class);
@@ -191,7 +193,7 @@ class OrderTest extends BaseTest {
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("c617f0ff-f819-477f-a17b-a8d248c4443e");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getDescription()).isEqualTo("DID");
         assertThat(created.getItems()).hasSize(1);
     }
@@ -212,16 +214,16 @@ class OrderTest extends BaseTest {
         Order order = new Order();
         order.setAllowBackOrdering(true);
         order.setCallbackUrl("https://example.com/callback");
-        order.setCallbackMethod("POST");
+        order.setCallbackMethod(CallbackMethod.POST);
         order.setItems(Collections.singletonList(item));
 
         ApiResponse<Order> response = client.orders().create(order);
         Order created = response.getData();
 
         assertThat(created.getId()).isEqualTo("5da18706-be9f-49b0-aeec-0480aacd49ad");
-        assertThat(created.getStatus()).isEqualTo("Pending");
+        assertThat(created.getStatus()).isEqualTo(OrderStatus.PENDING);
         assertThat(created.getCallbackUrl()).isEqualTo("https://example.com/callback");
-        assertThat(created.getCallbackMethod()).isEqualTo("POST");
+        assertThat(created.getCallbackMethod()).isEqualTo(CallbackMethod.POST);
         assertThat(created.getItems()).hasSize(1);
     }
 }

--- a/src/test/java/com/didww/sdk/resource/RequirementTest.java
+++ b/src/test/java/com/didww/sdk/resource/RequirementTest.java
@@ -2,6 +2,7 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.IdentityType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -25,7 +26,7 @@ class RequirementTest extends BaseTest {
         assertThat(requirements).isNotEmpty();
         assertThat(requirements).hasSize(5);
         assertThat(requirements.get(0).getId()).isEqualTo("b6c80acb-3952-4d53-9e62-fe2348c0636b");
-        assertThat(requirements.get(0).getIdentityType()).isEqualTo("Any");
+        assertThat(requirements.get(0).getIdentityType()).isEqualTo(IdentityType.ANY);
     }
 
     @Test
@@ -40,7 +41,7 @@ class RequirementTest extends BaseTest {
         Requirement requirement = response.getData();
 
         assertThat(requirement.getId()).isEqualTo("25d12afe-1ec6-4fe3-9621-b250dd1fb959");
-        assertThat(requirement.getIdentityType()).isEqualTo("Any");
+        assertThat(requirement.getIdentityType()).isEqualTo(IdentityType.ANY);
         assertThat(requirement.getPersonalAreaLevel()).isEqualTo("WorldWide");
         assertThat(requirement.getPersonalProofQty()).isEqualTo(1);
         assertThat(requirement.getServiceDescriptionRequired()).isTrue();

--- a/src/test/java/com/didww/sdk/resource/VoiceInTrunkTest.java
+++ b/src/test/java/com/didww/sdk/resource/VoiceInTrunkTest.java
@@ -3,6 +3,7 @@ package com.didww.sdk.resource;
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
 import com.didww.sdk.resource.configuration.PstnConfiguration;
+import com.didww.sdk.resource.enums.CliFormat;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -30,7 +31,7 @@ class VoiceInTrunkTest extends BaseTest {
         assertThat(first.getName()).isEqualTo("iax2 trunk sample");
         assertThat(first.getPriority()).isEqualTo(1);
         assertThat(first.getWeight()).isEqualTo(65535);
-        assertThat(first.getCliFormat()).isEqualTo("e164");
+        assertThat(first.getCliFormat()).isEqualTo(CliFormat.E164);
     }
 
     @Test

--- a/src/test/java/com/didww/sdk/resource/VoiceOutTrunkTest.java
+++ b/src/test/java/com/didww/sdk/resource/VoiceOutTrunkTest.java
@@ -2,6 +2,10 @@ package com.didww.sdk.resource;
 
 import com.didww.sdk.BaseTest;
 import com.didww.sdk.repository.ApiResponse;
+import com.didww.sdk.resource.enums.DefaultDstAction;
+import com.didww.sdk.resource.enums.MediaEncryptionMode;
+import com.didww.sdk.resource.enums.OnCliMismatchAction;
+import com.didww.sdk.resource.enums.VoiceOutTrunkStatus;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -38,12 +42,12 @@ class VoiceOutTrunkTest extends BaseTest {
         VoiceOutTrunk trunk = response.getData();
 
         assertThat(trunk.getName()).isEqualTo("test");
-        assertThat(trunk.getStatus()).isEqualTo("blocked");
+        assertThat(trunk.getStatus()).isEqualTo(VoiceOutTrunkStatus.BLOCKED);
         assertThat(trunk.getCapacityLimit()).isEqualTo(123);
         assertThat(trunk.getAllowAnyDidAsCli()).isFalse();
-        assertThat(trunk.getOnCliMismatchAction()).isEqualTo("replace_cli");
-        assertThat(trunk.getMediaEncryptionMode()).isEqualTo("srtp_sdes");
-        assertThat(trunk.getDefaultDstAction()).isEqualTo("reject_all");
+        assertThat(trunk.getOnCliMismatchAction()).isEqualTo(OnCliMismatchAction.REPLACE_CLI);
+        assertThat(trunk.getMediaEncryptionMode()).isEqualTo(MediaEncryptionMode.SRTP_SDES);
+        assertThat(trunk.getDefaultDstAction()).isEqualTo(DefaultDstAction.REJECT_ALL);
         assertThat(trunk.getForceSymmetricRtp()).isTrue();
         assertThat(trunk.getRtpPing()).isTrue();
         assertThat(trunk.getThresholdReached()).isFalse();
@@ -66,7 +70,7 @@ class VoiceOutTrunkTest extends BaseTest {
         VoiceOutTrunk trunk = new VoiceOutTrunk();
         trunk.setName("php-test");
         trunk.setAllowedSipIps(Collections.singletonList("0.0.0.0/0"));
-        trunk.setOnCliMismatchAction("replace_cli");
+        trunk.setOnCliMismatchAction(OnCliMismatchAction.REPLACE_CLI);
         trunk.setDefaultDid(did);
         trunk.setDids(Collections.singletonList(did));
 
@@ -75,7 +79,7 @@ class VoiceOutTrunkTest extends BaseTest {
 
         assertThat(created.getId()).isEqualTo("b60201c1-21f0-4d9a-aafa-0e6d1e12f22e");
         assertThat(created.getName()).isEqualTo("php-test");
-        assertThat(created.getStatus()).isEqualTo("active");
+        assertThat(created.getStatus()).isEqualTo(VoiceOutTrunkStatus.ACTIVE);
     }
 
     @Test


### PR DESCRIPTION
Replace String/Integer types with type-safe enums for all fields with fixed allowed values: CliFormat, MediaEncryptionMode, StirShakenMode, OnCliMismatchAction, DefaultDstAction, VoiceOutTrunkStatus, IdentityType, CallbackMethod, ExportType, OrderStatus, AddressVerificationStatus, ExportStatus, Feature, TransportProtocol, SstRefreshMethod, RxDtmfFormat, TxDtmfFormat, and Codec. Also adds mediaEncryptionMode and stirShakenMode fields to SipConfiguration.