### PR TITLE
docs(readme): correct SDK version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This SDK sends the `X-DIDWW-API-Version: 2026-04-16` header with every request b
 
 | SDK Version | Branch | DIDWW API Version |
 |-------------|--------|-------------------|
-| **3.x** | [`main`](https://github.com/didww/didww-api-3-java-sdk) | [`2026-04-16`](https://doc.didww.com/api3/2026-04-16/index.html) |
-| **2.x** | [`2022-05-10`](https://github.com/didww/didww-api-3-java-sdk/tree/2022-05-10) | [`2022-05-10`](https://doc.didww.com/api3/2022-05-10/index.html) |
+| **4.x** | [`main`](https://github.com/didww/didww-api-3-java-sdk) | [`2026-04-16`](https://doc.didww.com/api3/2026-04-16/index.html) |
+| **3.x** | [`2022-05-10`](https://github.com/didww/didww-api-3-java-sdk/tree/2022-05-10) | [`2022-05-10`](https://doc.didww.com/api3/2022-05-10/index.html) |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

The SDK version table at the top of the README was stale:

- It mapped \`3.x → main → 2026-04-16\`, but \`main\` ships **v4.0.0** with API 2026-04-16.
- It mapped \`2.x → 2022-05-10\`, but the \`2022-05-10\` branch was tagged through **v3.0.0**.

Updated table:

| SDK Version | Branch | DIDWW API Version |
|-------------|--------|-------------------|
| **4.x** | \`main\` | \`2026-04-16\` |
| **3.x** | \`2022-05-10\` | \`2022-05-10\` |

## Test plan
- [x] No code changes — pure docs.
- [x] Verified tags: \`git log 4.0.0\` is at tip of \`main\`; \`git log 3.0.0\` is at tip of \`2022-05-10\`.