### PR TITLE
chore(fixtures): use example.com placeholder for webhook callback host

### DIFF
--- a/src/test/resources/fixtures/dids/show_with_address_verification_and_did_group.json
+++ b/src/test/resources/fixtures/dids/show_with_address_verification_and_did_group.json
@@ -135,7 +135,7 @@
             "type": "address_verifications",
             "attributes": {
                 "service_description": "Address verification for registration 01kjan2paw2wfqndqdkd2m3hyc",
-                "callback_url": "https://didwwwebhook.aurora-dev.sinchlab.com/AuroraDIDWWWebhookService/api/didww/verification/callback/119881627",
+                "callback_url": "https://example.com/webhook/verification/callback/119881627",
                 "callback_method": "post",
                 "status": "approved",
                 "reject_reasons": null,


### PR DESCRIPTION
The `dids/show_with_address_verification_and_did_group.json` fixture was recorded with a real customer webhook host in `callback_url`. Replaced with the RFC 2606 `example.com` placeholder